### PR TITLE
Expand emscripten support to supporting JS imported closures.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,10 @@
 [target.'cfg(target_arch = "wasm32")']
 runner = 'cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner --'
+
+[build]
+[target.'cfg(all(target_arch = "wasm32", target_os = "emscripten"))']
+rustflags = [
+    "-Cllvm-args=-enable-emscripten-cxx-exceptions=0", 
+    "-Clink-arg=-Wno-undefined",    
+    "-Crelocation-model=static",                                                                                                                                                                                                     
+]

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.0"
 walrus = { version = "0.23", features = ['parallel'] }
+regex = "1"
 wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.100' }
 wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.100' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.100' }


### PR DESCRIPTION
This PR also includes the change to the interpreter's global get instruction to work with target triple `wasm32-unknown-emscripten`.