### PR TITLE
Get futures to work with emscripten mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ runner = 'cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner --'
 [target.'cfg(all(target_arch = "wasm32", target_os = "emscripten"))']
 rustflags = [
   "-Cllvm-args=-enable-emscripten-cxx-exceptions=0",
+  "-Clink-arg=-sERROR_ON_UNDEFINED_SYMBOLS=0",
   "-Clink-arg=-Wno-undefined",
   "-Crelocation-model=static",
 ]


### PR DESCRIPTION
One thing to note regarding the implementation:
in order to avoid littering the code base with `import_deps.insert("$random_symbol")` in random places, I attempt to centralize these insertions in `expose_$symbol` functions where makes more sense. Hence why you will see a lot more passing of `import_deps`.  